### PR TITLE
Release docker image for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF##*/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u cathive -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            cathive/concourse-sonarqube-resource:${{ steps.prepare.outputs.tag_name }}
+            cathive/concourse-sonarqube-resource:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG SONAR_SCANNER_MAVEN_PLUGIN_VERSION="3.7.0.1746"
 # =================================================
 # Builder image (just for downloads / preparations)
 # =================================================
-FROM debian:jessie as builder
+FROM debian:latest as builder
 RUN apt-get -y update && apt-get -y install curl unzip
 ARG MAVEN_VERSION
 ARG MAVEN_SHA512_CHECKSUM


### PR DESCRIPTION
Hi

**Package Owner:** Prakriti Chauhan

**PR change Details:**

**$ Patch Details:** Following files has been modified and added:

- **.github/workflows/ci.yml:** Added this file to use buildx in github actions to build and push the image for both the platforms to dockerhub.

- **Dockerfile:** **debian:jessie** is not available for arm64 so replaced it with **debian:latest** image.

**$ Testing Detail :**

- **Github actions Link -** https://github.com/prakritichauhan07/concourse-sonarqube-resource/runs/2406993688?check_suite_focus=true

- **Dockerhub Link -** https://hub.docker.com/repository/docker/sakshi9715/concourse-sonarqube-resource

**$ PR Description:** Here is my commit message :
Release docker image for arm64

Here is my PR description -
The following files have been modified and added:

- Added **.github/workflows/ci.yml** file to use buildx in github actions in order to build and push the image for both the platforms to dockerhub.

- In the **Dockerfile** file **debian:jessie** image is not available for arm64 so replaced it with **debian:latest** image.

**$Reviewer:** Pruthvi Teja Reddy

Thanks
Prakriti Chauhan